### PR TITLE
Vignette updated with code

### DIFF
--- a/vignettes/How-to.Rmd
+++ b/vignettes/How-to.Rmd
@@ -59,9 +59,8 @@ Consider “narrowing” eligibility criteria to exclude problematic sub-populat
 ## Set Up: load packages
 
 ```{r message=FALSE, warning=FALSE}
-library(RDS)
-library(ggplot2)
 library(tidyverse)
+library(RDS)
 ```
 
 
@@ -81,19 +80,34 @@ If you are importing RDS data from a non-RDS file format (e.g., .xls or .csv), i
 
 ### Convert Data to RDS Format
 
-`as.rds.data.frame` RDS Object:		*.rdsobj, *.rdsat
-
-
 Whether you automatically access the data conversion function upon uploading data or choose it from the Data menu, there are two possible RDS data formats:
 
-#### Coupon format
-
-In this format there are several columns in the data containing coupon numbers. One column is for each respondent's own coupon, and the others (e.g. coupon.1, coupon.2, etc.) list the coupons they may have distributed. Thus, the recruitment path is stored through the coupon numbers. The seeds generally have own coupon numbers of 0, NA or something similar. Upon conversion, columns identifying each respondent's recruiter ID, wave and seed are created if not already present.
-
-#### Recruiter ID format
+#### Recruiter ID format (long-format)
 
 Rather than tracking recruitment paths through coupons, in this format a Recruiter ID column records the subject ID of the recruiter for each respondent. Seeds are identified by a shared recruiter ID such as 0. Upon conversion, columns identifying each respondent's wave and seed are created if not already present.
 Example: Convert nyjazz data set to RDS coupon format
+
+```{r}
+data("faux")
+data("fauxmadrona")
+
+# We'll convert the 'faux' dataset into a tibble similar to what we'd get from reading in a CSV for illustration purposes
+faux <- as_tibble(faux)
+
+# And then back to the proper format
+faux <- 
+  faux %>% 
+  as.rds.data.frame(
+    id = "id",
+    recruiter.id = "recruiter.id",
+    network.size = "network.size")
+```
+
+#### Coupon format (wide-format)
+
+In this format there are several columns in the data containing coupon numbers. One column is for each respondent's own coupon, and the others (e.g. coupon.1, coupon.2, etc.) list the coupons they may have distributed. Thus, the recruitment path is stored through the coupon numbers. The seeds generally have own coupon numbers of 0, NA or something similar. Upon conversion, columns identifying each respondent's recruiter ID, wave and seed are created if not already present.
+
+Data in coupon format has to be converted to recruiter format before being passed to `as.rds.data.frame()`. The standard `dplyr` tibble pivoting verbs can be of help here.
 
 #### Common Data Problems & Solutions
 
@@ -108,13 +122,6 @@ Example: Convert nyjazz data set to RDS coupon format
  * Rounding error in IDS Problem Coupon or ID variables are numeric and some have 15 or more digits.  Symptom Recruitment structure incorrectly read in except when using .rdsat and .rdsobj formats. Solution 1.Edit variables to have non-numeric type (e.g. add a “c” to the beginning of all coupon variables). 2.Put data file in .rdsat format
 
 
-Example on nyjazzdf 
-
-```{r }
-#mtcars[c("V8")] <- recode.variables(mtcars[c("cyl")] , "8 -> 1;else -> 0;") 
-```
-
-
 ### Edit RDS Meta Data
 
 An RDS data set's "Meta Data" stores information about the variable names associated with: 
@@ -125,36 +132,45 @@ An RDS data set's "Meta Data" stores information about the variable names associ
  *  __Max # of Coupons__: The number of recruitment coupons distributed to each participant.
  *  __Population Size Estimate__: Mid values may be used as the default population size. 
  
- 
+You can view those attributes the usual way:
 
-### Recode Variables
-
-The Recode Variables dialog allows to substitute values into existing variables, or create new variables based on current variables.
-
-The following example uses the mtcars data set, which can be loaded by entering data(mtcars) into the console. 
-
-```{r }
-#mtcars[c("V8")] <- recode.variables(mtcars[c("cyl")] , "8 -> 1;else -> 0;") 
+```{r}
+attributes(faux) %>% str() # passing to str() to reduce output size
 ```
 
 
+### Recode Variables
+
+If necessary, you can use the `forcats` package to recode, reorder, or collapse factors as necessary for analysis.  
 
 
 ### Export (Save) Data
 
 
-
-The Export Data dialog (under the File menu) allows storage of RDS data in several formats:
+The `write.*` function of families can be used to export data into any of the following formats:
 
  *  __RDS Analyst (.rdsobj)__ - Stores a RDS data frame in the native RDS analyst format, and does not need to be converted if re-imported to RDS Analyst (see RDSAnalystImportRDSData)
  *  __Flat File (.robj, .csv)__ - Uses the dput function to write an ASCII text representation of a data frame to a file or connection (.robj).
  *  __ Netdraw (.dl, .vna)__ - Stores a RDS data frame's recruitment tree in NetDraw format
  *  __GraphViz (.gz)__ - Stores a RDS data frame's recruitment tree as a GraphViz file 
 
+```{r, eval = FALSE}
+write.rdsat(faux, "faux") # the '.rdsat' extension is added automatically
+```
 
 
 ## Visualize and Summarize Data
 
+Since the `rds.data.frame` class only exists for method dispatch, you can inspect objects of `rds.data.frame` like any other data.frame by printing them to the console or using RStudio's built-in data viewer.
+
+```{r}
+# print to the console
+glimpse(faux)
+
+# built-in viewer (only works in interactive sessions)
+if (interactive())
+  View(faux)
+```
 
 ### Plot the Recruitment Tree 
 
@@ -164,44 +180,53 @@ Are the chains long?
 Do most of the subjects come from the same seed?
 Visualize homophily.
 
+```{r}
+plot(faux)
+```
 
+Underneath the hood, `plot()` calls `reingold.tilford.plot()` which allows for customizing the color, size, and labels of the vertices as desired. See the function documentation for more details and pass the arguments into `plot()`.
 
 ### Plot Recruitment Diagnostics
 The Recruitment Diagnostics creates up to five charts, providing a snapshot of the recruitment process:
 
  * Network Size by wave  
+ 
+```{r}
+plot(faux, plot.type = "Network size by wave")
+```
+ 
  * Recruits by wave  
+ 
+```{r}
+ plot(faux, plot.type = "Recruits by wave")
+```
+
  * Recruits by Seeds  
+ 
+```{r}
+ plot(faux, plot.type = "Recruits per seed")
+```
+
  * Recruits by subject  
  
+```{r}
+ plot(faux, plot.type = "Recruits per subject")
+```
+
 Does network size change over the course of sampling? 
 How many recruits are in each wave? 
 How many recruits originate from each seed?
 
-### Plot Basic Statistics
-
-Continuous Variables 
-
- * Look at descriptive statistics (Sample > Descriptives)
- * Plot histograms (Plots > Quick > Histogram) 
-
-Categorical Variables
-
-* Look at Frequencies (Sample > Frequencies) 
-* Make bar charts (Plots > Quick > bar)
-
-Relationships
-
- * Crosstabs (Sample > Contingency Tables > chi-squared) 
- * Descriptives with strata (Sample DescriptivesL mean, standard variation)
-
 ## Analyze Data
-
 
 
 ### Population Frequency Estimates
 
 This dialog computes a point estimate and confidence interval of population frequency (prevalence), for one or more categorical variables. 
+
+```{r}
+RDS.bootstrap.intervals(faux, outcome.variable = "X")
+```
 
 The default method is Gile's SS estimator, where the confidence interval is computed using Gile's bootstrap method. This is a computationally-intensive procedure and can take a minute or longer to complete.
 
@@ -211,7 +236,11 @@ Convergence plots help to determine whether the final RDS estimate is biased by 
 
 measures progression of enrolling subjects to determine when the proportion for a characteristic approaches and remains stable in relation to the adjusted estimate
 
-The convergence plots below show a data set that has converged (left, using fauxmadrona sample data) and one that has not (right).
+```{r}
+convergence.plot(fauxmadrona, outcome.variable = "disease")
+```
+
+The convergence plots below show a data set that has converged using fauxmadrona.
 
 Note that although the plot on the left shows convergence, there is a chance that additional data would not follow this trend. The recruitment tree could be stuck in a sub-population of the population of interest. This is discussed further below.
 
@@ -233,18 +262,30 @@ An example of this scenario is described in "Diagnostics for Respondent-driven S
 
 Each line of a bottleneck plots tracks an estimate of a characteristic of an interest based on one of the seeds. If the estimates converge as the samples from each seed (their trees) grow, then there is no indication of a bottleneck along this characteristic.
 
-Below are two bottleneck plots prepared from the fauxmadrona data set. (To load fauxmadrona, select "Example: fauxmadrona" from the Packages & Data menu). Both track the samples originating from each of the 10 seeds, as labeled by ID in the legend at right. (Note that the lines for each seed end at different places, reflecting the different sizes of the trees that originate from each seed.) The plot on the left tracks the estimate of the prevalence of disease in the population. While the estimates start at a range of values, they all converge toward about 20%, showing no evidence of divided sub-communities of infected and uninfected. Similarly, the plot at right tracks the samples along a completely randomized 0/1 indicator variable for the population. As expected, the prevalence estimates of this indicator converge toward .5, with some variation around that estimate.
+Below are two bottleneck plots prepared from the fauxmadrona data set. Both track the samples originating from each of the 10 seeds, as labeled by ID in the legend at right. (Note that the lines for each seed end at different places, reflecting the different sizes of the trees that originate from each seed.) The first plot tracks the estimate of the prevalence of disease in the population. While the estimates start at a range of values, they all converge toward about 20%, showing no evidence of divided sub-communities of infected and uninfected.
+
+```{r}
+bottleneck.plot(fauxmadrona, outcome.variable = "disease")
+```
+
+Similarly, the plot at right tracks the samples along a completely randomized 0/1 indicator variable for the population. As expected, the prevalence estimates of this indicator converge toward .5, with some variation around that estimate.
+
+```{r}
+bottleneck.plot(fauxmadrona %>% mutate(random = runif(nrow(fauxmadrona))), outcome.variable = "random")
+```
 
 In comparison, a plot with evidence of bottlenecks is shown below. The estimates stabilize at different places depending on where the seeds originate.
 
+![bottlenecked](http://www.deducer.org/pmwiki/uploads/Main/bottleneck_plots2.png)
 
 ### Population Contingency Tables (Crosstabs)
-The Population Crosstabs creates contingency tables for the target population based on inference from the sample. The tables show the estimated marginal and joint distribution of characteristics in the population. The column and row totals give point estimates (prevalence rates) for the selected variables -- in the example below, the row totals give the percentage of "blue" and "red" in the population based on RDS-II sampling weights. The tables can optionally be stratified by another variable in the data. Below they are stratified by wave.
+The Population Crosstabs creates contingency tables for the target population based on inference from the sample. The tables show the estimated marginal and joint distribution of characteristics in the population. The column and row totals give point estimates (prevalence rates) for the selected variables -- in the example below, the row totals give the percentage of "blue" and "red" in the population based on RDS-II sampling weights.
+
+```{r}
+bootstrap.contingency.test(faux, row.var = "X", col.var = "Y", table.only = TRUE)
+```
 
 Disclaimer: These tables do not show the uncertainty in the estimates. To get a sense of the uncertainty, use the Frequency Estimates dialog, which returns confidence intervals along with point estimates. The point estimates from that dialog should approximately match the ones here if the selected weight type and other settings match.
-
-If you would like to view a contingency table for the sample data alone (no inference on the population) use the Contingency Tables dialog under the Sample menu
- 
 
 ### Test Difference in Population Proportions / Prevalence
 
@@ -252,7 +293,12 @@ The Test Difference in Proportions is used to compare population frequency estim
 
 For example, the following compares the frequency of classes of the X and Y variables of the "faux" data set.
 
+```{r}
+est_x <- RDS.bootstrap.intervals(faux, outcome.variable = "X")
+est_y <- RDS.bootstrap.intervals(faux, outcome.variable = "Y")
 
+RDS.compare.proportions(est_x, est_y)
+```
 
 ### Compute Sampling Weights
 
@@ -266,7 +312,9 @@ he Compute Weights dialog under the Data menu to calculate sampling weights base
 
 For Gile's SS and RDS-II, weights will be unique for each reported network size. For RDS-I and RDS-I (DS), weights will be unique for each class of the Group Variable.
 
-
+```{r, eval = FALSE}
+compute.weights(fauxmadrona, weight.type = "Gile's SS", N = attr(fauxmadrona, "population.size.mid"))
+```
 
 ### Recruitment Homophily & Population Homophily
 
@@ -279,16 +327,17 @@ If the recruitment homophily on disease status is about 1, we see little effect 
 
 The following shows how to calculate recruitment homophily on disease status for the fauxmadrona data set. 
 
+```{r}
+homophily.estimates(fauxmadrona, outcome.variable = "disease", recruitment = TRUE)
+```
+
 Tendency of like to recruit like. 
 Lots of homophily -> High Variance 
 
 Homophily near 1 means no homophily
 p-values assume a simple random sample, so only use them as rough guides. 
 
-
-
-Population Homophily is very similar to recruitment homophily, except here we estimate the homophily for the population as a whole, and the function only outputs that estimate (no other descriptives). The function demands an additional estimate of the population size, which can be calculated using the size package. (Note, the homophily estimate may not be very sensitive to the population size estimate.) For further description of homophily, see the recruitment homophily page.
-
+Population Homophily (calculcated when `recruitment = FALSE`)is very similar to recruitment homophily, except here we estimate the homophily for the population as a whole, and the function only outputs that estimate (no other descriptives). The function demands an additional estimate of the population size, which can be calculated using the size package. (Note, the homophily estimate may not be very sensitive to the population size estimate.) For further description of homophily, see the recruitment homophily page.
 
 ### Compare Network Activity of Sub-populations: Differential Activity
 
@@ -296,14 +345,15 @@ The distribution of network size (a.k.a. degree) of members of the target popula
 
 The user inputs the choice of data set and binary variable(s) on which to compare members of the population, e.g. disease status.
 
-The output is, for example:
-"The mean degree of those with value 1 divided by the mean degree of those without is 0.6189263"
+```{r}
+differential.activity.estimates(fauxmadrona, outcome.variable = "disease")
+```
 
 Note that "those with value 1" refers to the group that is ordered second alphabetically or numerically. If the variable has named states, e.g. "blue" and "red", the function will order alphabetically by default. If the states are integers, "those with value 1" would be those with the higher-number state.
-
 
 ### Test of trend
 
 This function compute a hypothesis test of trend in prevalence based on a likelihood-ratio statistic. It takes a series of point estimates and their associated standard errors and computes the p-value for the test of a monotone decrease in the population prevalences (in sequence order). 
 
 The p-value for a monotone increase is also reported. An optional plot of the estimates and the null distribution of the test statistics is provided. 
+


### PR DESCRIPTION
The vignette still has a couple of issues that need to be sorted out:
* The narrative needs to be revised to remove all references to the GUI workflow.
* The plots used to produce counter-examples in the documentation weren't generated using the faux data that comes with the package so they're missing from the vignette. You can easily identify them on the wiki from the grey background. See here for example: http://www.deducer.org/pmwiki/index.php?n=Main.RDSAnalystFrequencyEstimates
* The data for the very last section, "Test of Trend", doesn't come from the package either. Couldn't add any code there.

And do note that I've removed the section on plotting because it's only relevant to the GUI users. The same plots can be produced using ggplot2 and the like.